### PR TITLE
Better NGINX support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Polymath
 
 Polymath is a web server designed to host resource packs of the Oraxen plugin.
-
+__ __
 ## How to use Polymath
 
 - Clone the project
@@ -44,3 +44,36 @@ toml
 ./run``
 
 - Polymath should now be running
+
+__ __
+## How to use on Pterodactyl or Windows
+
+- Clone the project
+``git clone git@github.com:oraxen/Polymath`` or ``git clone https://github.com/oraxen/Polymath``
+
+- Install [Python](https://python.org) (tested on 3.10!)
+
+- install following requirements (use pip or requirements.txt)
+```
+aiohttp>=3.7.4
+toml>=0.10.2
+colorama>=0.4.5
+```
+
+- use python to start /polymouth/core.py
+
+#### you **must** setup SSL for this to work! 
+
+### if using nginx:
+- setup a new vhost in /etc/nginx/sites-available/
+- setup ssl (u can use [certbot](https://certbot.eff.org/))
+- change the location of the VHOST to something like: 
+```nginx
+location / {
+    proxy_pass http://127.0.0.1:8080;
+    proxy_set_header X-Real-IP $remote_addr;
+    client_max_body_size 10M;
+}
+```
+> i recommend using a subdomain like texture.example.xyz
+- make sure port 443 is forwarded!

--- a/polymath/config/settings.template.toml
+++ b/polymath/config/settings.template.toml
@@ -3,6 +3,7 @@ port = "8080"
 url = "http://atlas.oraxen.com:8080"
 nginx = false
 print_debug = false
+print_startup = "hello pterodactyl" # use this to give pterodactyl the started signal!
 
 [request]
 max_size = 100000000 # 100 MB

--- a/polymath/config/settings.template.toml
+++ b/polymath/config/settings.template.toml
@@ -1,6 +1,8 @@
 [server]
 port = "8080"
 url = "http://atlas.oraxen.com:8080"
+nginx = false
+print_debug = false
 
 [request]
 max_size = 100000000 # 100 MB
@@ -8,3 +10,8 @@ max_size = 100000000 # 100 MB
 [cleaner]
 delay = 21600 # every 6 hours
 pack_lifespan = 604800 # remove a pack after 7 days without downloads
+
+[nginx]
+ip_header = "X-Real-IP" # the header in which the IP is saved
+only_listen_nginx = true # sets the listen host to below if needed.
+nginx_location = "127.0.0.1"  # if nginx is running on same host, may be different depen. the env.

--- a/polymath/core.py
+++ b/polymath/core.py
@@ -4,7 +4,7 @@ from aiohttp import web
 import asyncio
 import server
 import cleaner
-
+import os
 
 async def main():
     # load the config
@@ -12,15 +12,20 @@ async def main():
     if not config.configured:
         return
 
+    host_ip = config['nginx']['nginx_location'] if config['server']['nginx'] and config['nginx']['only_listen_nginx'] else '0.0.0.0'
+    
     app = web.Application(client_max_size=config["request"]["max_size"])
     packs_manager = PacksManager(config)
     server.setup(app, config, packs_manager)
 
+    _ = os.system('cls') if os.name == 'nt' else os.system('clear')
+
+    print("Oraxen Polymouth running on: http://"+host_ip+':'+config["server"]["port"])
+    print("Test URL: http://127.0.0.1:"+config["server"]["port"]+"/debug")
+    print("="*70)
     runner = web.AppRunner(app)
     await runner.setup()
-    await web.TCPSite(runner, port=config["server"]["port"]).start()
+    await web.TCPSite(runner,host=host_ip ,port=config["server"]["port"]).start()
     await cleaner.start(packs_manager, config)
     await asyncio.Event().wait()
-
-
 asyncio.run(main())

--- a/polymath/core.py
+++ b/polymath/core.py
@@ -18,9 +18,10 @@ async def main():
     packs_manager = PacksManager(config)
     server.setup(app, config, packs_manager)
 
+    print(config['server']['print_startup'])
     _ = os.system('cls') if os.name == 'nt' else os.system('clear')
 
-    print("Oraxen Polymouth running on: http://"+host_ip+':'+config["server"]["port"])
+    print("Oraxen Polymouth Listening on: http://"+host_ip+':'+config["server"]["port"])
     print("Test URL: http://127.0.0.1:"+config["server"]["port"]+"/debug")
     print("="*70)
     runner = web.AppRunner(app)
@@ -28,4 +29,5 @@ async def main():
     await web.TCPSite(runner,host=host_ip ,port=config["server"]["port"]).start()
     await cleaner.start(packs_manager, config)
     await asyncio.Event().wait()
+    
 asyncio.run(main())

--- a/polymath/server.py
+++ b/polymath/server.py
@@ -1,5 +1,8 @@
+from numbers import Real
 from aiohttp import web
-
+from datetime import datetime
+from colorama import Fore,init
+init()
 
 def setup(app, config, packs_manager):
     routes = Routes(config, packs_manager)
@@ -20,7 +23,18 @@ class Routes:
     def start(self):
         web.run_app(self.app)
 
+    def timestamp(self):
+        # "%m/%d/%Y, %H:%M:%S"
+        # 06/12/2018, 09:55:22
+        now = datetime.now()
+        return "["+now.strftime("%m/%d/%Y")+"]["+now.strftime("%H:%M:%S")+"]"
+    
     async def upload(self, request):
+        # set the IP depending on the enviroment.        
+        Real_IP = request.headers[ self.config['nginx']['ip_header'] ] if self.config["server"]["nginx"] else request.remote
+
+        if self.config['server']['print_debug']: print(self.timestamp()+Fore.GREEN+"[UPLOAD]"+Fore.RESET+" Received Upload request from: "+Real_IP)
+        
         """
         Allow to upload a resourcepack with a spigot id
 
@@ -40,7 +54,7 @@ class Routes:
             return web.json_response({"error": "This license has been disabled"})
 
         pack = data["pack"].file.read()
-        id_hash = self.packs.register(pack, spigot_id, request.remote)
+        id_hash = self.packs.register(pack, spigot_id, Real_IP) # use the above header if behind e.x.: nginx
 
         return web.json_response(
             {
@@ -51,6 +65,8 @@ class Routes:
 
     # To download a resourcepack from its id
     async def download(self, request):
+        if self.config['server']['print_debug']: print(self.timestamp()+Fore.GREEN+"[UPLOAD]"+Fore.RESET+" Received User Download request.")
+        
         """
         Allow to download a resourcepack with a spigot id
 
@@ -71,7 +87,7 @@ class Routes:
             return web.FileResponse(pack, headers={"content-type": "application/zip"})
 
     async def debug(self, request):
-        print(type(request))
+        print(self.timestamp()+Fore.YELLOW+"[DEBUG] "+Fore.RESET+str(type(request)))
         """
         Allow to test the connection
 

--- a/polymath/server.py
+++ b/polymath/server.py
@@ -65,7 +65,7 @@ class Routes:
 
     # To download a resourcepack from its id
     async def download(self, request):
-        if self.config['server']['print_debug']: print(self.timestamp()+Fore.GREEN+"[UPLOAD]"+Fore.RESET+" Received User Download request.")
+        if self.config['server']['print_debug']: print(self.timestamp()+Fore.GREEN+"[DOWNLOAD]"+Fore.RESET+" Received User Download request.")
         
         """
         Allow to download a resourcepack with a spigot id


### PR DESCRIPTION
I added some option in the settings to add better support for pterodactyl and NGINX.
You can now set a header which contains the IP address to fix the issue, only getting "127.0.0.1" behind NGINX.
Also added some documentation to run this on pterodactyl / windows.
For some added security, you could set this up to only listen on 127.0.0.1 and let NGINX handle all out / in going request / SSL.
Also, I added some debug options, so you can see the server working, as some users were wondering if it actually is running.
In General, tried to make the output a bit more organized.
