### PR TITLE
Missing Requirement, Docker Compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ If you didn't install nix, you need to install Python 3.8 with those packages:
 cython
 aiohttp
 toml
+colorama
 ```
 
 - Build polymath
@@ -67,6 +68,7 @@ __ __
 aiohttp>=3.7.4
 toml>=0.10.2
 cython
+colorama
 ```
 #### you **must** setup SSL for this to work! 
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ __ __
 - Clone the project
 ``git clone git@github.com:oraxen/Polymath`` or ``git clone https://github.com/oraxen/Polymath``
 
-- Install [Python](https://python.org) (tested on 3.10!)
+- Install [Python](https://python.org) (tested on Python 3.12.3!)
 
 - install following requirements (use pip or requirements.txt):
 ``pip  install -r requirements.txt``
@@ -66,7 +66,7 @@ __ __
 ```
 aiohttp>=3.7.4
 toml>=0.10.2
-colorama>=0.4.5
+cython
 ```
 #### you **must** setup SSL for this to work! 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,6 @@ services:
     build: .
     command: python -u run
     restart: always
-    ports:
-      - 8080:8080
     volumes:
       - ./_docker/polymath:/polymath/polymath/storage
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
 
   polymath:

--- a/polymath/server.py
+++ b/polymath/server.py
@@ -74,7 +74,6 @@ class Routes:
 
     # To download a resourcepack from its id
     async def download(self, request):
-        # if self.config['extra']['print_debug'] and self.config['extra']['debug_level'] == 0: print(self.timestamp()+Fore.GREEN+"[DOWNLOAD]"+Fore.RESET+" Received User Download request.")
         logging.debug("Received User Download request.")
         
         Real_IP = request.headers[ self.config['nginx']['ip_header'] ] if self.config["nginx"]["enabled"] else request.remote

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 cython
 aiohttp
 toml
-colorama
+colorama>=0.4.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 cython
 aiohttp
 toml
+colorama


### PR DESCRIPTION
I realized I missed putting in the “Colorama” Requirement, should I remove it?

Also Changed Docker compose a bit, to remove Deprecated Version and a little more Security by not Exposing the Polymath port (Only Nginx expose is needed.)

Now Tested to work with Python 3.12.3 and removed an old commented line of code.
These are not big changes, just some to clean up a bit :D.